### PR TITLE
Refactor some code

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -58,7 +58,6 @@ impl<R: Read> Read for StripHeaderReader<R> {
 }
 
 impl<R: Read> StripHeaderReader<R> {
-
     fn strip_head_read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut backing = vec![0; buf.len()];
         let mut local_buf : &mut [u8] = &mut *backing;
@@ -155,7 +154,7 @@ pub fn parse_vlq_segment(segment: &str) -> Result<Vec<i64>> {
 
     if cur != 0 || shift != 0 {
         Err(Error::VlqLeftover)
-    } else if rv.len() == 0 {
+    } else if rv.is_empty() {
         Err(Error::VlqNoValues)
     } else {
         Ok(rv)
@@ -201,7 +200,7 @@ fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         dst_col = 0;
 
         for segment in line.split(',') {
-            if segment.len() == 0 {
+            if segment.is_empty() {
                 continue;
             }
 
@@ -254,9 +253,9 @@ fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         if !source_root.is_empty() {
             let source_root = source_root.trim_right_matches('/');
             sources = sources.into_iter().map(|x| {
-                if x.len() > 0 && (x.starts_with('/') ||
-                                   x.starts_with("http:") ||
-                                   x.starts_with("https:")) {
+                if !x.is_empty() &&
+                    (x.starts_with('/') || x.starts_with("http:") || x.starts_with("https:"))
+                {
                     x
                 } else {
                     format!("{}/{}", source_root, x)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -192,8 +192,8 @@ fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 
     let mut tokens = vec![];
     let mut index = vec![];
-    let names = rsm.names.unwrap_or(vec![]);
-    let mut sources = rsm.sources.unwrap_or_else(|| vec![]);
+    let names = rsm.names.unwrap_or_else(Vec::new);
+    let mut sources = rsm.sources.unwrap_or_else(Vec::new);
     let mappings = rsm.mappings.unwrap_or_else(|| "".into());
 
     for (dst_line, line) in mappings.split(';').enumerate() {
@@ -283,7 +283,7 @@ fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
 fn decode_index(rsm: RawSourceMap) -> Result<SourceMapIndex> {
     let mut sections = vec![];
 
-    for mut raw_section in rsm.sections.unwrap_or(vec![]) {
+    for mut raw_section in rsm.sections.unwrap_or_else(Vec::new) {
         sections.push(SourceMapSection::new(
             (raw_section.offset.line, raw_section.offset.column),
             raw_section.url,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -171,12 +171,11 @@ pub enum DecodedMap {
 }
 
 impl DecodedMap {
-
     /// Shortcut to look up a token on either an index or a
     /// regular sourcemap.  This method can only be used if
     /// the contained index actually contains embedded maps
     /// or it will not be able to look up anything.
-    pub fn lookup_token<'a>(&'a self, line: u32, col: u32) -> Option<Token<'a>> {
+    pub fn lookup_token(&self, line: u32, col: u32) -> Option<Token> {
         match *self {
             DecodedMap::Regular(ref sm) => sm.lookup_token(line, col),
             DecodedMap::Index(ref smi) => smi.lookup_token(line, col),

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,7 +218,6 @@ pub struct SourceMap {
 }
 
 impl SourceMap {
-
     /// Creates a sourcemap from a reader over a JSON stream in UTF-8
     /// format.  Optionally a "garbage header" as defined by the
     /// sourcemap draft specification is supported.  In case an indexed
@@ -298,7 +297,7 @@ impl SourceMap {
     }
 
     /// Looks up a token by its index.
-    pub fn get_token<'a>(&'a self, idx: u32) -> Option<Token<'a>> {
+    pub fn get_token(&self, idx: u32) -> Option<Token> {
         self.tokens.get(idx as usize).map(|raw| {
             Token { raw: raw, i: self }
         })
@@ -310,12 +309,12 @@ impl SourceMap {
     }
 
     /// Returns an iterator over the tokens.
-    pub fn tokens<'a>(&'a self) -> TokenIter<'a> {
+    pub fn tokens(&self) -> TokenIter {
         TokenIter { i: self, next_idx: 0 }
     }
 
     /// Looks up the closest token to a given line and column.
-    pub fn lookup_token<'a>(&'a self, line: u32, col: u32) -> Option<Token<'a>> {
+    pub fn lookup_token(&self, line: u32, col: u32) -> Option<Token> {
         let mut low = 0;
         let mut high = self.index.len();
 
@@ -353,7 +352,7 @@ impl SourceMap {
     }
 
     /// Returns an iterator over the names.
-    pub fn names<'a>(&'a self) -> NameIter<'a> {
+    pub fn names(&self) -> NameIter {
         NameIter { i: self, next_idx: 0 }
     }
 
@@ -373,13 +372,12 @@ impl SourceMap {
     }
 
     /// Returns the number of items in the index
-    pub fn index_iter<'a>(&'a self) -> IndexIter<'a> {
+    pub fn index_iter(&self) -> IndexIter {
         IndexIter { i: self, next_idx: 0 }
     }
 }
 
 impl SourceMapIndex {
-
     /// Creates a sourcemap index from a reader over a JSON stream in UTF-8
     /// format.  Optionally a "garbage header" as defined by the
     /// sourcemap draft specification is supported.  In case a regular
@@ -442,7 +440,7 @@ impl SourceMapIndex {
     }
 
     /// Iterates over all sections
-    pub fn sections<'a>(&'a self) -> SourceMapSectionIter<'a> {
+    pub fn sections(&self) -> SourceMapSectionIter {
         SourceMapSectionIter {
             i: self,
             next_idx: 0
@@ -454,7 +452,7 @@ impl SourceMapIndex {
     /// This requires that the referenced sourcemaps are actually loaded.
     /// If a sourcemap is encountered that is not embedded but just
     /// externally referenced it is silently skipped.
-    pub fn lookup_token<'a>(&'a self, line: u32, col: u32) -> Option<Token<'a>> {
+    pub fn lookup_token(&self, line: u32, col: u32) -> Option<Token> {
         for section in self.sections() {
             let (off_line, off_col) = section.get_offset();
             if off_line < line || off_col < col {
@@ -536,7 +534,6 @@ impl SourceMapIndex {
 }
 
 impl SourceMapSection {
-
     /// Create a new sourcemap index section
     ///
     /// - `offset`: offset as line and column


### PR DESCRIPTION
Smaller things; this shouldn't change the semantics at all. (But might get rid of some `vec![]` call).
